### PR TITLE
chore(deps): update tutorial validation dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "cheerio": "^1.1.2",
+        "cheerio": "^1.2.0",
         "fs": "^0.0.1-security",
-        "js-yaml": "^4.1.0",
-        "marked": "^17.0.1",
+        "js-yaml": "^5.2.1",
+        "marked": "^18.0.5",
         "path": "^0.12.7"
       },
       "devDependencies": {
@@ -62,9 +62,9 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -72,11 +72,11 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -244,9 +244,9 @@
       }
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -258,14 +258,14 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -292,20 +292,31 @@
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
       "bin": {
-        "js-yaml": "bin/js-yaml.js"
+        "js-yaml": "bin/js-yaml.mjs"
       }
     },
     "node_modules/marked": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
-      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
@@ -411,9 +422,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -481,20 +492,20 @@
       }
     },
     "cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "requires": {
         "cheerio-select": "^2.1.0",
         "dom-serializer": "^2.0.0",
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       }
     },
@@ -602,20 +613,20 @@
       "dev": true
     },
     "htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "requires": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       },
       "dependencies": {
         "entities": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-          "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+          "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="
         }
       }
     },
@@ -633,17 +644,17 @@
       "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
     },
     "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
+      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
       "requires": {
         "argparse": "^2.0.1"
       }
     },
     "marked": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.1.tgz",
-      "integrity": "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w=="
     },
     "nth-check": {
       "version": "2.1.1",
@@ -714,9 +725,9 @@
       }
     },
     "undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw=="
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="
     },
     "util": {
       "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,10 @@
   },
   "homepage": "https://github.com/couchbase-examples/couchbase-tutorials#readme",
   "dependencies": {
-    "cheerio": "^1.1.2",
+    "cheerio": "^1.2.0",
     "fs": "^0.0.1-security",
-    "js-yaml": "^4.1.0",
-    "marked": "^17.0.1",
+    "js-yaml": "^5.2.1",
+    "marked": "^18.0.5",
     "path": "^0.12.7"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Updates direct npm dependencies used by the tutorial validation tooling:

- `cheerio` from `^1.1.2` to `^1.2.0`
- `js-yaml` from `^4.1.0` to `^5.2.1`
- `marked` from `^17.0.1` to `^18.0.5`
- Regenerates `package-lock.json` with npm using the existing package manager

Linked Hermes Kanban task: `t_fa1387da`

## Updated dependencies

| Ecosystem | Dependency | Previous | Updated | Type | Notes |
| --- | --- | --- | --- | --- | --- |
| npm | `cheerio` | `^1.1.2` | `^1.2.0` | dependency | Latest stable; requires Node >=20.18.1, compatible with CI Node 22 |
| npm | `js-yaml` | `^4.1.0` | `^5.2.1` | dependency | Latest stable |
| npm | `marked` | `^17.0.1` | `^18.0.5` | dependency | Latest stable; requires Node >=20, compatible with CI Node 22 |

## Skipped / constraint-limited dependencies

| Dependency | Current | Latest | Reason |
| --- | --- | --- | --- |
| `chalk` | `4.1.2` | `5.6.2` | Skipped because `chalk@5` is ESM-only (`type: module`) while the validation scripts currently use CommonJS `require('chalk')`. |
| `fs` | `0.0.1-security` | `0.0.1-security` | Already current. |
| `path` | `0.12.7` | `0.12.7` | Already current. |

## Validation

Commands run locally on Node `v22.23.1` and npm `10.9.8`:

```shell
npm install
npm ci
npm run test:frontmatter
npm outdated --json
```

Outcomes:

| Check | Result | Notes |
| --- | --- | --- |
| Install / lockfile regeneration | Passed | `npm install` completed; 38 packages audited; 0 vulnerabilities reported by npm audit. |
| Clean CI-style install | Passed | `npm ci` completed successfully. |
| Frontmatter validation | Passed | `npm run test:frontmatter` completed with `Test Completed: SUCCESS`. |
| Generic `npm test` | Not applicable | Existing package script is the npm placeholder `echo "Error: no test specified" && exit 1`; repository CI uses `npm run test:frontmatter` directly. |
| Browser evidence | Not applicable | This repository change only affects validation tooling dependencies for markdown/tutorial content; no runnable web surface was changed. |
| Swagger/OpenAPI evidence | Not applicable | No API surface is built or changed by this repository update. |

## Risk notes

- `cheerio` and `marked` both require modern Node versions; the repository workflow already runs Node 22.
- `marked` is a major-version update. The existing `require('marked')` usage was validated by `npm run test:frontmatter` after the update.
- `chalk@5` was intentionally not updated because it would require an ESM migration in the current CommonJS test script.

## Rollback

Revert this PR to restore the previous `package.json` and `package-lock.json` dependency versions.
